### PR TITLE
Clarification made to the PPSSPP Windows guide regarding MAC addresses.

### DIFF
--- a/emulation/ppsspp-windows.md
+++ b/emulation/ppsspp-windows.md
@@ -79,9 +79,7 @@ You can find places to connect to at <https://ppsspp.org/adhoc.html>.
 
 	MacAddress = 
 
-The Mac address is a random address which differentiates your device
-from others in a server or network, or something like that. This is,
-at least, what it does in PPSSPP. If you play online, you’ll need to
+The Mac (Media Access Control) address is a random alphanumeric sequence that is tied to your NIC (Network Interface Card) and uniquely identifies your device on a network. If you play online, you’ll need to
 make this different from the default. Perhaps you can use your
 computer’s Mac Address to make it different enough.
 


### PR DESCRIPTION
The MAC address section of the PPSSPP Windows guide has been modified to include a clearer, more precise definition of a MAC address.
Research gathered from https://techterms.com/definition/macaddress